### PR TITLE
add github Actions CD config for pypi release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,60 @@
+name: CD
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Many color libraries just need this to be set to any value, but at least
+  # one distinguishes color depth, where "3" -> "256-bit color".
+  FORCE_COLOR: 3
+
+jobs:
+  dist:
+    name: Distribution build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  publish:
+    needs: [dist]
+    name: Publish to PyPI
+    environment: pypi
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Generate artifact attestation for sdist and wheel
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*"
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Remember to tell (test-)pypi about this repo before publishing
+          # Remove this line to publish to PyPI
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
   publish:
     needs: [dist]
     name: Publish to PyPI
-    environment: pypi
+    environment: test-pypi
     permissions:
       id-token: write
       attestations: write


### PR DESCRIPTION
This is based on [this file](https://github.com/scientific-python/cookie/blob/main/%7B%7Bcookiecutter.project_name%7D%7D/.github/workflows/%7B%25%20if%20cookiecutter.__type!%3D'compiled'%20%25%7Dcd.yml%7B%25%20endif%20%25%7D) which I also use elsewhere via the cookiecutter template it is part of.

Next step is to configure an account (mine?) on pypi (or first on test-pypi) to allow publishing via this action.

Problem is that we can only test if things work once we have merged this PR and have created a release via Github.